### PR TITLE
Correctly detect array returned from JSONPath array filter.

### DIFF
--- a/lib/jsonpath-object-transform.js
+++ b/lib/jsonpath-object-transform.js
@@ -96,8 +96,10 @@
 
     if (seek.length && subpath) {
       result = result[key] = [];
+      // JSONPath filtering does not result in a nested array.
+      var list = Array.isArray(seek[0]) ? seek[0] : seek;
 
-      seek[0].forEach(function(item, index) {
+      list.forEach(function(item, index) {
         walk(item, subpath, result, index);
       });
     } else {


### PR DESCRIPTION
This follows from #9. I'm not exactly sure why "normal" JSONPath arrays are nested, but those that are filtered are not. This may also not be the right place to introduce this logic, but it seems safe.